### PR TITLE
Added support for Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,11 @@ To compile Sealang, you'll need to:
 
 1. Make sure you have Python >= 3.7
 2. Install LLVM 10.0 (with clang)
-3. Set some environment variables
+    Note about Windows: You might need to compile the project. Follow the steps here_ to compile it (You must enable the ``clang`` project)
+3. Set the environment variable ``LLVM_HOME`` to the root of the compiled LLVM project
 4. pip install git+https://github.com/gtors/sealang#egg=sealang-10.0
 
+.. _here: https://github.com/llvm/llvm-project
 
 Usage
 -----

--- a/sealang/sealang.h
+++ b/sealang/sealang.h
@@ -7,6 +7,12 @@
 #include "clang-c/Index.h"
 #include "clang-c/CXString.h"
 
+#ifdef _WIN32
+#define EXPORT_PREFIX __declspec(dllexport)
+#else
+#define EXPORT_PREFIX
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -14,46 +20,46 @@ extern "C" {
 /**
  * \brief Returns string representation of unary and binary operators
  */
-CXString clang_Cursor_getOperatorString(CXCursor cursor);
+EXPORT_PREFIX CXString clang_Cursor_getOperatorString(CXCursor cursor);
 
 /**
  * \brief Returns Opcode of binary operator
  */
-clang::BinaryOperatorKind clang_Cursor_getBinaryOpcode(CXCursor cursor);
+EXPORT_PREFIX clang::BinaryOperatorKind clang_Cursor_getBinaryOpcode(CXCursor cursor);
 
 /**
  * \brief Returns Opcode of unary operator
  */
-clang::UnaryOperatorKind clang_Cursor_getUnaryOpcode(CXCursor cursor);
+EXPORT_PREFIX clang::UnaryOperatorKind clang_Cursor_getUnaryOpcode(CXCursor cursor);
 
 /**
  * \brief Returns string representation of literal cursor (1.f, 1000L, etc)
  */
-CXString clang_Cursor_getLiteralString(CXCursor cursor);
+EXPORT_PREFIX CXString clang_Cursor_getLiteralString(CXCursor cursor);
 
 /**
  * \brief Returns for-loop init cursor [for(init;cond;inc)], or CXCursor_NoDeclFound if there is no decl,
  * or CXCursor_InvalidCode if C is not CXCursor_ForStmt
  */
-// CXCursor clang_getForStmtInit(CXCursor C);
+// EXPORT_PREFIX CXCursor clang_getForStmtInit(CXCursor C);
 
 /**
  * \brief Returns for-loop condition cursor [for(init;cond;inc)], or CXCursor_NoDeclFound if there is no decl,
  * or CXCursor_InvalidCode if C is not CXCursor_ForStmt
  */
-// CXCursor clang_getForStmtCond(CXCursor C);
+// EXPORT_PREFIX CXCursor clang_getForStmtCond(CXCursor C);
 
 /**
  * \brief Returns for-loop increment cursor [for(init;cond;inc)], or CXCursor_NoDeclFound if there is no decl,
  * or CXCursor_InvalidCode if C is not CXCursor_ForStmt
  */
-// CXCursor clang_getForStmtInc(CXCursor C);
+// EXPORT_PREFIXCXCursor clang_getForStmtInc(CXCursor C);
 
 /**
  * \brief Returns for-loop body, or CXCursor_NoDeclFound if there is no decl,
  * or CXCursor_InvalidCode if C is not CXCursor_ForStmt
  */
-// CXCursor clang_getForStmtBody(CXCursor C);
+// EXPORT_PREFIX CXCursor clang_getForStmtBody(CXCursor C);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Changes:
- Added explicit libraries in `setup.py` due to `clang-cpp` not being available on Windows as a library

## Issues with this implementation:
- On Windows you'll need to manually compile LLVM as stated in the `README.rst` but also move a couple of include directories to satisfy `cl.exe`.